### PR TITLE
temporarily removed path alias for lib and changed mimetype to string

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,10 +7,11 @@ export type PlaylistID = ObjectID;
 
 export type CID = string;
 export type JWT = string;
+export type MimeType = string;
 
 export type IPFSContent = {
   hash: CID;
-  type: MimeType;
+  mimeType: MimeType;
 };
 
 export interface AccountInfo {


### PR DESCRIPTION
@cjayross these are some changes I need for westegg to work at the moment. Path aliasing is not working after doing yarn build, so temporarily removing it so we can fix later. Also mimetype is a dom type that I don't have access to in nodejs and it would be more trouble than it's worth to convert between the two, so I updated it to a string aliased as MimeType.